### PR TITLE
⬆️Update bump tag strategy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+---
+name: ":bow: posting pull request"
+about: feature request for EmojiPicker
+title: ""
+labels: minor
+assignees: nkpgardose
+---

--- a/.github/workflows/tags-and-versioning-workflow.yml
+++ b/.github/workflows/tags-and-versioning-workflow.yml
@@ -12,5 +12,6 @@ jobs:
         uses: K-Phoen/semver-release-action@master
         with:
           release_branch: master
+          release_strategy: tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When merging PR to master. **Only** use `git tag` without `release`